### PR TITLE
Spin symmetry for Bogoliubov transform and Gaussian states

### DIFF
--- a/examples/tutorial_2_diagonal_coulomb_trotter.ipynb
+++ b/examples/tutorial_2_diagonal_coulomb_trotter.ipynb
@@ -146,7 +146,7 @@
     "\n",
     "# Obtain the Bogoliubov transformation matrix.\n",
     "quadratic_hamiltonian = openfermion.QuadraticHamiltonian(hamiltonian.one_body)\n",
-    "transformation_matrix = quadratic_hamiltonian.diagonalizing_bogoliubov_transform()\n",
+    "_, transformation_matrix, _ = quadratic_hamiltonian.diagonalizing_bogoliubov_transform()\n",
     "\n",
     "# Create a circuit that prepares the mean-field state\n",
     "occupied_orbitals = range(n_electrons)\n",

--- a/openfermioncirq/gates/four_qubit_gates_test.py
+++ b/openfermioncirq/gates/four_qubit_gates_test.py
@@ -17,7 +17,6 @@ import scipy
 import cirq
 import openfermion
 
-from cirq.testing import EqualsTester
 from openfermioncirq.gates import DoubleExcitation, DoubleExcitationGate
 
 
@@ -33,7 +32,7 @@ def test_double_excitation_init_with_multiple_args_fails():
 
 
 def test_double_excitation_eq():
-    eq = EqualsTester()
+    eq = cirq.testing.EqualsTester()
 
     eq.add_equality_group(DoubleExcitationGate(half_turns=1.5),
                           DoubleExcitationGate(half_turns=-0.5),

--- a/openfermioncirq/primitives/bogoliubov_transform_test.py
+++ b/openfermioncirq/primitives/bogoliubov_transform_test.py
@@ -66,8 +66,6 @@ def test_spin_symmetric_bogoliubov_transform(
         atol=5e-5):
     n_qubits = 2*n_spatial_orbitals
     qubits = LineQubit.range(n_qubits)
-    up_qubits = qubits[:n_spatial_orbitals]
-    down_qubits = qubits[n_spatial_orbitals:]
 
     # Initialize a random quadratic Hamiltonian
     quad_ham = random_quadratic_hamiltonian(
@@ -85,15 +83,13 @@ def test_spin_symmetric_bogoliubov_transform(
     )
     quad_ham_sparse = get_sparse_operator(quad_ham)
 
-    # Compute the orbital energies and circuit
-    up_orbital_energies, up_transformation_matrix, _ = (
+    # Compute the orbital energies and transformation_matrix
+    up_orbital_energies, _, _ = (
             quad_ham.diagonalizing_bogoliubov_transform(spin_sector=0))
-    up_circuit = cirq.Circuit.from_ops(
-            bogoliubov_transform(up_qubits, up_transformation_matrix))
-    down_orbital_energies, down_transformation_matrix, _ = (
+    down_orbital_energies, _, _ = (
             quad_ham.diagonalizing_bogoliubov_transform(spin_sector=1))
-    down_circuit = cirq.Circuit.from_ops(
-            bogoliubov_transform(down_qubits, down_transformation_matrix))
+    _, transformation_matrix, _ = (
+            quad_ham.diagonalizing_bogoliubov_transform())
 
     # Pick some orbitals to occupy
     up_orbitals = list(range(2))
@@ -109,7 +105,9 @@ def test_spin_symmetric_bogoliubov_transform(
     )
 
     # Apply the circuit
-    circuit = up_circuit + down_circuit
+    circuit = cirq.Circuit.from_ops(
+            bogoliubov_transform(
+                qubits, transformation_matrix, initial_state=initial_state))
     state = circuit.apply_unitary_effect_to_state(initial_state)
 
     # Check that the result is an eigenstate with the correct eigenvalue

--- a/openfermioncirq/primitives/bogoliubov_transform_test.py
+++ b/openfermioncirq/primitives/bogoliubov_transform_test.py
@@ -18,7 +18,7 @@ import pytest
 import cirq
 from cirq import LineQubit
 import openfermion
-from openfermion import get_sparse_operator, down_index, up_index
+from openfermion import get_sparse_operator
 from openfermion.utils import (
         random_quadratic_hamiltonian, random_unitary_matrix)
 

--- a/openfermioncirq/primitives/bogoliubov_transform_test.py
+++ b/openfermioncirq/primitives/bogoliubov_transform_test.py
@@ -71,7 +71,7 @@ def test_bogoliubov_transform_quadratic_hamiltonian(n_qubits,
 
     # Compute the orbital energies and circuit
     orbital_energies, constant = quad_ham.orbital_energies()
-    transformation_matrix = quad_ham.diagonalizing_bogoliubov_transform()
+    _, transformation_matrix, _ = quad_ham.diagonalizing_bogoliubov_transform()
     circuit = cirq.Circuit.from_ops(
             bogoliubov_transform(qubits, transformation_matrix))
 
@@ -148,7 +148,7 @@ def test_bogoliubov_transform_quadratic_hamiltonian_inverse_is_dagger(
             real=real,
             conserves_particle_number=particle_conserving,
             seed=46533)
-    transformation_matrix = quad_ham.diagonalizing_bogoliubov_transform()
+    _, transformation_matrix, _ = quad_ham.diagonalizing_bogoliubov_transform()
 
     qubits = cirq.LineQubit.range(n_qubits)
 

--- a/openfermioncirq/primitives/state_preparation.py
+++ b/openfermioncirq/primitives/state_preparation.py
@@ -68,7 +68,7 @@ def prepare_gaussian_state(qubits: Sequence[cirq.QubitId],
             Default is 0, the all zeros state.
     """
     n_qubits = len(qubits)
-    if occupied_orbitals is None or isinstance(occupied_orbitals[0], int):
+    if not occupied_orbitals or isinstance(occupied_orbitals[0], int):
         # Generic
         yield _generic_gaussian_circuit(
                 qubits, quadratic_hamiltonian, occupied_orbitals, initial_state)

--- a/openfermioncirq/primitives/state_preparation.py
+++ b/openfermioncirq/primitives/state_preparation.py
@@ -20,9 +20,7 @@ import cirq
 from openfermion import (
         QuadraticHamiltonian,
         gaussian_state_preparation_circuit,
-        slater_determinant_preparation_circuit,
-        down_index,
-        up_index)
+        slater_determinant_preparation_circuit)
 
 from openfermioncirq import YXXY
 
@@ -48,7 +46,9 @@ def prepare_gaussian_state(qubits: Sequence[cirq.QubitId],
         occupied_orbitals: Integers representing the indices of the
             pseudoparticle orbitals to occupy in the Gaussian state.
             If two lists are given, then the first list specifies spin-up
-            orbitals and the second list specifies spin-down orbitals.
+            orbitals and the second list specifies spin-down orbitals,
+            and the circuit requires that modes be reordered so that
+            spin-up modes come before spin-down modes.
             Two lists should be given only if the Hamiltonian contains a
             spin degree of freedom and modes with different spin do not
             interact.
@@ -124,7 +124,8 @@ def _spin_symmetric_gaussian_circuit(
                     spin_sector=spin_sector)
         )
 
-        index_map = (up_index, down_index)[spin_sector]
+        def index_map(i):
+            return i + spin_sector*(n_qubits // 2)
         spin_indices = [index_map(i) for i in range(n_qubits // 2)]
         spin_qubits = [qubits[i] for i in spin_indices]
 

--- a/openfermioncirq/primitives/state_preparation.py
+++ b/openfermioncirq/primitives/state_preparation.py
@@ -67,13 +67,15 @@ def prepare_gaussian_state(qubits: Sequence[cirq.QubitId],
             example, the list [2, 3] represents qubits 2 and 3 being set to one.
             Default is 0, the all zeros state.
     """
-    n_qubits = len(qubits)
     if not occupied_orbitals or isinstance(occupied_orbitals[0], int):
         # Generic
+        occupied_orbitals = cast(Sequence[int], occupied_orbitals)
         yield _generic_gaussian_circuit(
                 qubits, quadratic_hamiltonian, occupied_orbitals, initial_state)
     else:
         # Spin symmetry
+        occupied_orbitals = cast(Tuple[Sequence[int], Sequence[int]],
+                                 occupied_orbitals)
         yield _spin_symmetric_gaussian_circuit(
                 qubits, quadratic_hamiltonian, occupied_orbitals, initial_state)
 
@@ -105,7 +107,7 @@ def _generic_gaussian_circuit(
 def _spin_symmetric_gaussian_circuit(
         qubits: Sequence[cirq.QubitId],
         quadratic_hamiltonian: QuadraticHamiltonian,
-        occupied_orbitals: Optional[Tuple[Sequence[int], Sequence[int]]],
+        occupied_orbitals: Tuple[Sequence[int], Sequence[int]],
         initial_state: Union[int, Sequence[int]]) -> cirq.OP_TREE:
 
     n_qubits = len(qubits)

--- a/openfermioncirq/primitives/state_preparation.py
+++ b/openfermioncirq/primitives/state_preparation.py
@@ -47,7 +47,7 @@ def prepare_gaussian_state(qubits: Sequence[cirq.QubitId],
             pseudoparticle orbitals to occupy in the Gaussian state.
             If two lists are given, then the first list specifies spin-up
             orbitals and the second list specifies spin-down orbitals,
-            and the circuit requires that modes be reordered so that
+            and the modes are assumed to be ordered so that
             spin-up modes come before spin-down modes.
             Two lists should be given only if the Hamiltonian contains a
             spin degree of freedom and modes with different spin do not

--- a/openfermioncirq/primitives/state_preparation.py
+++ b/openfermioncirq/primitives/state_preparation.py
@@ -12,7 +12,7 @@
 
 """Operations for preparing useful quantum states."""
 
-from typing import Iterable, Sequence, Set, Tuple, Union, cast
+from typing import Iterable, Optional, Sequence, Set, Tuple, Union, cast
 
 import numpy
 
@@ -20,14 +20,19 @@ import cirq
 from openfermion import (
         QuadraticHamiltonian,
         gaussian_state_preparation_circuit,
-        slater_determinant_preparation_circuit)
+        slater_determinant_preparation_circuit,
+        down_index,
+        up_index)
 
 from openfermioncirq import YXXY
 
 
 def prepare_gaussian_state(qubits: Sequence[cirq.QubitId],
                            quadratic_hamiltonian: QuadraticHamiltonian,
-                           occupied_orbitals: Sequence[int]=None,
+                           occupied_orbitals: Optional[Union[
+                               Sequence[int],
+                               Tuple[Sequence[int], Sequence[int]]
+                               ]]=None,
                            initial_state: Union[int, Sequence[int]]=0
                            ) -> cirq.OP_TREE:
     """Prepare a fermionic Gaussian state from a computational basis state.
@@ -40,9 +45,14 @@ def prepare_gaussian_state(qubits: Sequence[cirq.QubitId],
     Args:
         qubits: The qubits to which to apply the circuit.
         quadratic_hamiltonian: The Hamiltonian whose eigenstate is desired.
-        occupied_orbitals: A list of integers representing the indices of the
-            pseudoparticle orbitals to occupy in the Gaussian state. The
-            orbitals are ordered in ascending order of energy.
+        occupied_orbitals: Integers representing the indices of the
+            pseudoparticle orbitals to occupy in the Gaussian state.
+            If two lists are given, then the first list specifies spin-up
+            orbitals and the second list specifies spin-down orbitals.
+            Two lists should be given only if the Hamiltonian contains a
+            spin degree of freedom and modes with different spin do not
+            interact.
+            The orbitals are ordered in ascending order of energy.
             The default behavior is to fill the orbitals with negative energy,
             i.e., prepare the ground state.
         initial_state: The computational basis state that the qubits start in.
@@ -57,6 +67,23 @@ def prepare_gaussian_state(qubits: Sequence[cirq.QubitId],
             example, the list [2, 3] represents qubits 2 and 3 being set to one.
             Default is 0, the all zeros state.
     """
+    n_qubits = len(qubits)
+    if occupied_orbitals is None or isinstance(occupied_orbitals[0], int):
+        # Generic
+        yield _generic_gaussian_circuit(
+                qubits, quadratic_hamiltonian, occupied_orbitals, initial_state)
+    else:
+        # Spin symmetry
+        yield _spin_symmetric_gaussian_circuit(
+                qubits, quadratic_hamiltonian, occupied_orbitals, initial_state)
+
+
+def _generic_gaussian_circuit(
+        qubits: Sequence[cirq.QubitId],
+        quadratic_hamiltonian: QuadraticHamiltonian,
+        occupied_orbitals: Optional[Sequence[int]],
+        initial_state: Union[int, Sequence[int]]) -> cirq.OP_TREE:
+
     n_qubits = len(qubits)
     circuit_description, start_orbitals = gaussian_state_preparation_circuit(
             quadratic_hamiltonian, occupied_orbitals)
@@ -73,6 +100,41 @@ def prepare_gaussian_state(qubits: Sequence[cirq.QubitId],
 
     yield _ops_from_givens_rotations_circuit_description(
             qubits, circuit_description)
+
+
+def _spin_symmetric_gaussian_circuit(
+        qubits: Sequence[cirq.QubitId],
+        quadratic_hamiltonian: QuadraticHamiltonian,
+        occupied_orbitals: Optional[Tuple[Sequence[int], Sequence[int]]],
+        initial_state: Union[int, Sequence[int]]) -> cirq.OP_TREE:
+
+    n_qubits = len(qubits)
+
+    if isinstance(initial_state, int):
+        initially_occupied_orbitals = _occupied_orbitals(
+                initial_state, n_qubits)
+    else:
+        initially_occupied_orbitals = initial_state  # type: ignore
+
+    for spin_sector in range(2):
+        circuit_description, start_orbitals = (
+                gaussian_state_preparation_circuit(
+                    quadratic_hamiltonian,
+                    occupied_orbitals[spin_sector],
+                    spin_sector=spin_sector)
+        )
+
+        index_map = (up_index, down_index)[spin_sector]
+        spin_indices = [index_map(i) for i in range(n_qubits // 2)]
+        spin_qubits = [qubits[i] for i in spin_indices]
+
+        # Flip bits so that the correct starting orbitals are occupied
+        yield (cirq.X(spin_qubits[j]) for j in range(n_qubits // 2)
+               if (index_map(j) in initially_occupied_orbitals)
+               != (index_map(j) in [index_map(k) for k in start_orbitals]))
+
+        yield _ops_from_givens_rotations_circuit_description(
+                spin_qubits, circuit_description)
 
 
 def prepare_slater_determinant(qubits: Sequence[cirq.QubitId],

--- a/openfermioncirq/primitives/state_preparation_test.py
+++ b/openfermioncirq/primitives/state_preparation_test.py
@@ -64,6 +64,62 @@ def test_prepare_gaussian_state(n_qubits,
 
 
 @pytest.mark.parametrize(
+        'n_spatial_orbitals, conserves_particle_number, occupied_orbitals, '
+        'initial_state',
+        [(4, True, [range(1), range(1)], 0b00100100),
+         (5, True, [range(2), range(1)], 0),
+         (5, True, [[0, 2], [1, 3]], 0)])
+def test_prepare_gaussian_state_with_spin_symmetry(n_spatial_orbitals,
+                                                   conserves_particle_number,
+                                                   occupied_orbitals,
+                                                   initial_state,
+                                                   atol=1e-5):
+
+    n_qubits = 2 * n_spatial_orbitals
+    qubits = LineQubit.range(n_qubits)
+    if isinstance(initial_state, list):
+        initial_state = sum(1 << (n_qubits - 1 - i) for i in initial_state)
+
+    # Initialize a random quadratic Hamiltonian
+    quad_ham = random_quadratic_hamiltonian(
+            n_spatial_orbitals,
+            conserves_particle_number,
+            real=True,
+            expand_spin=True)
+    quad_ham.constant = 0.0
+    quad_ham_sparse = get_sparse_operator(quad_ham)
+
+    # Compute the energy of the desired state
+    energy = 0.0
+    for spin_sector in range(2):
+        orbital_energies, _, _ = (
+            quad_ham.diagonalizing_bogoliubov_transform(
+                spin_sector=spin_sector)
+        )
+        energy += sum(orbital_energies[i]
+                      for i in occupied_orbitals[spin_sector])
+
+    # Get the state using a circuit simulation
+    circuit = cirq.Circuit.from_ops(
+            prepare_gaussian_state(
+                qubits, quad_ham, occupied_orbitals,
+                initial_state=initial_state))
+    state = circuit.apply_unitary_effect_to_state(initial_state)
+
+    import openfermion
+    numpy.testing.assert_allclose(
+            openfermion.variance(quad_ham_sparse, state),
+            0.0)
+    numpy.testing.assert_allclose(
+            openfermion.expectation(quad_ham_sparse, state),
+            energy)
+
+    # Check that the result is an eigenstate with the correct eigenvalue
+    numpy.testing.assert_allclose(
+            quad_ham_sparse.dot(state), energy * state, atol=atol)
+
+
+@pytest.mark.parametrize(
         'slater_determinant_matrix, correct_state, initial_state',
         [(numpy.array([[1, 1]]) / numpy.sqrt(2),
           numpy.array([0, 1, 1, 0]) / numpy.sqrt(2),

--- a/openfermioncirq/primitives/state_preparation_test.py
+++ b/openfermioncirq/primitives/state_preparation_test.py
@@ -49,7 +49,8 @@ def test_prepare_gaussian_state(n_qubits,
     if occupied_orbitals is None:
         energy = quad_ham.ground_energy()
     else:
-        orbital_energies, constant = quad_ham.orbital_energies()
+        orbital_energies, _, constant = (
+                quad_ham.diagonalizing_bogoliubov_transform())
         energy = sum(orbital_energies[i] for i in occupied_orbitals) + constant
 
     # Get the state using a circuit simulation
@@ -68,7 +69,7 @@ def test_prepare_gaussian_state(n_qubits,
         'n_spatial_orbitals, conserves_particle_number, occupied_orbitals, '
         'initial_state',
         [(4, True, [range(1), range(1)], 0b00100100),
-         (5, True, [range(2), range(1)], range(3)),
+         (5, True, [range(2), range(1)], list(range(3))),
          (5, True, [[0, 2], [1, 3]], 0)])
 def test_prepare_gaussian_state_with_spin_symmetry(n_spatial_orbitals,
                                                    conserves_particle_number,
@@ -78,8 +79,6 @@ def test_prepare_gaussian_state_with_spin_symmetry(n_spatial_orbitals,
 
     n_qubits = 2 * n_spatial_orbitals
     qubits = LineQubit.range(n_qubits)
-    if isinstance(initial_state, list):
-        initial_state = sum(1 << (n_qubits - 1 - i) for i in initial_state)
 
     # Initialize a random quadratic Hamiltonian
     quad_ham = random_quadratic_hamiltonian(
@@ -113,6 +112,9 @@ def test_prepare_gaussian_state_with_spin_symmetry(n_spatial_orbitals,
             prepare_gaussian_state(
                 qubits, quad_ham, occupied_orbitals,
                 initial_state=initial_state))
+
+    if isinstance(initial_state, list):
+        initial_state = sum(1 << (n_qubits - 1 - i) for i in initial_state)
     state = circuit.apply_unitary_effect_to_state(initial_state)
 
     # Check that the result is an eigenstate with the correct eigenvalue

--- a/openfermioncirq/primitives/state_preparation_test.py
+++ b/openfermioncirq/primitives/state_preparation_test.py
@@ -68,7 +68,7 @@ def test_prepare_gaussian_state(n_qubits,
         'n_spatial_orbitals, conserves_particle_number, occupied_orbitals, '
         'initial_state',
         [(4, True, [range(1), range(1)], 0b00100100),
-         (5, True, [range(2), range(1)], 0),
+         (5, True, [range(2), range(1)], range(3)),
          (5, True, [[0, 2], [1, 3]], 0)])
 def test_prepare_gaussian_state_with_spin_symmetry(n_spatial_orbitals,
                                                    conserves_particle_number,

--- a/openfermioncirq/trotter/algorithms/low_rank.py
+++ b/openfermioncirq/trotter/algorithms/low_rank.py
@@ -132,9 +132,9 @@ class LowRankTrotterStep(TrotterStep):
         one_body_coefficients = (
                 hamiltonian.one_body_tensor + one_body_correction)
         quad_ham = openfermion.QuadraticHamiltonian(one_body_coefficients)
-        self.one_body_energies, _ = quad_ham.orbital_energies()
-        self.one_body_basis_change_matrix = (
-                quad_ham.diagonalizing_bogoliubov_transform())
+        self.one_body_energies, self.one_body_basis_change_matrix, _ = (
+                quad_ham.diagonalizing_bogoliubov_transform()
+        )
 
         super().__init__(hamiltonian)
 

--- a/openfermioncirq/trotter/algorithms/split_operator.py
+++ b/openfermioncirq/trotter/algorithms/split_operator.py
@@ -62,11 +62,11 @@ class SplitOperatorTrotterStep(TrotterStep):
 
     def __init__(self, hamiltonian: DiagonalCoulombHamiltonian) -> None:
         quad_ham = QuadraticHamiltonian(hamiltonian.one_body)
-        # Get the coefficients of the one-body terms in the diagonalizing basis
-        self.orbital_energies, _ = quad_ham.orbital_energies()
         # Get the basis change matrix that diagonalizes the one-body term
-        self.basis_change_matrix = (
-                quad_ham.diagonalizing_bogoliubov_transform())
+        # and associated orbital energies
+        self.orbital_energies, self.basis_change_matrix, _ = (
+                quad_ham.diagonalizing_bogoliubov_transform()
+        )
         super().__init__(hamiltonian)
 
 

--- a/openfermioncirq/trotter/simulate_trotter_test.py
+++ b/openfermioncirq/trotter/simulate_trotter_test.py
@@ -80,6 +80,16 @@ diag_coul_initial_state, diag_coul_exact_state = (
             diag_coul_hamiltonian, long_time, seed=49075)
 )
 
+# Hubbard model, reordered
+hubbard_model = openfermion.fermi_hubbard(2, 2, 1.0, 4.0)
+hubbard_model = openfermion.reorder(hubbard_model, openfermion.up_then_down)
+hubbard_hamiltonian = openfermion.get_diagonal_coulomb_hamiltonian(
+        hubbard_model)
+hubbard_initial_state, hubbard_exact_state = (
+        produce_simulation_test_parameters(
+            hubbard_hamiltonian, long_time, seed=8200)
+)
+
 # 4-qubit H2 2-2 with bond length 0.7414
 bond_length = 0.7414
 geometry = [('H', (0., 0., 0.)), ('H', (0., 0., bond_length))]
@@ -116,6 +126,10 @@ lih_initial_state, lih_exact_state = produce_simulation_test_parameters(
                 diag_coul_exact_state, 1, 1, SPLIT_OPERATOR, .99),
             (diag_coul_hamiltonian, long_time, diag_coul_initial_state,
                 diag_coul_exact_state, 2, 1, SPLIT_OPERATOR, .99999),
+            (hubbard_hamiltonian, long_time, hubbard_initial_state,
+                hubbard_exact_state, 0, 3, SPLIT_OPERATOR, .999),
+            (hubbard_hamiltonian, long_time, hubbard_initial_state,
+                hubbard_exact_state, 0, 6, SPLIT_OPERATOR, .9999),
             (h2_hamiltonian, longer_time, h2_initial_state,
                 h2_exact_state, 0, 1, LOW_RANK, .99),
             (h2_hamiltonian, longer_time, h2_initial_state,

--- a/openfermioncirq/variational/ansatzes/low_rank.py
+++ b/openfermioncirq/variational/ansatzes/low_rank.py
@@ -164,9 +164,9 @@ class LowRankTrotterAnsatz(VariationalAnsatz):
         one_body_coefficients = (
                 hamiltonian.one_body_tensor + self.one_body_correction)
         quad_ham = openfermion.QuadraticHamiltonian(one_body_coefficients)
-        self.one_body_energies, _ = quad_ham.orbital_energies()
-        self.one_body_basis_change_matrix = (
-                quad_ham.diagonalizing_bogoliubov_transform())
+        self.one_body_energies, self.one_body_basis_change_matrix, _ = (
+                quad_ham.diagonalizing_bogoliubov_transform()
+        )
 
         super().__init__(qubits)
 

--- a/openfermioncirq/variational/ansatzes/split_operator_trotter.py
+++ b/openfermioncirq/variational/ansatzes/split_operator_trotter.py
@@ -184,11 +184,11 @@ class SplitOperatorTrotterAnsatz(VariationalAnsatz):
         self.adiabatic_evolution_time = cast(float, adiabatic_evolution_time)
 
         quad_ham = openfermion.QuadraticHamiltonian(hamiltonian.one_body)
-        # Get the coefficients of the one-body terms in the diagonalizing basis
-        self.orbital_energies, _ = quad_ham.orbital_energies()
         # Get the basis change matrix that diagonalizes the one-body term
-        self.basis_change_matrix = (
-                quad_ham.diagonalizing_bogoliubov_transform())
+        # and associated orbital energies
+        self.orbital_energies, self.basis_change_matrix, _ = (
+                quad_ham.diagonalizing_bogoliubov_transform()
+        )
 
         super().__init__(qubits)
 


### PR DESCRIPTION
- Optimize Bogoliubov transformation circuits in particle-conserving case when transformation matrix is block diagonal with two blocks
- Allow preparing Gaussian states with specific spin orbitals when symmetries are present