### PR TITLE
citation update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,13 +72,14 @@ How to cite
 ===========
 When using OpenFermion-Cirq for research projects, please cite:
 
-    Jarrod R. McClean, Ian D. Kivlichan, Kevin J. Sung, Damian S. Steiger,
-    Yudong Cao, Chengyu Dai, E. Schuyler Fried, Craig Gidney, Brendan Gimby,
+    Jarrod R. McClean, Kevin J. Sung, Ian D. Kivlichan, Yudong Cao,
+    Chengyu Dai, E. Schuyler Fried, Craig Gidney, Brendan Gimby,
     Pranav Gokhale, Thomas Häner, Tarini Hardikar, Vojtĕch Havlíček,
-    Cupjin Huang, Josh Izaac, Zhang Jiang, Xinle Liu, Matthew Neeley,
-    Thomas O'Brien, Isil Ozfidan, Maxwell D. Radin, Jhonathan Romero,
-    Nicholas Rubin, Nicolas P. D. Sawaya, Kanav Setia, Sukin Sim,
-    Mark Steudtner, Qiming Sun, Wei Sun, Fang Zhang and Ryan Babbush.
+    Oscar Higgott, Cupjin Huang, Josh Izaac, Zhang Jiang, Xinle Liu,
+    Sam McArdle, Matthew Neeley, Thomas O'Brien, Bryan O'Gorman, Isil Ozfidan,
+    Maxwell D. Radin, Jhonathan Romero, Nicholas Rubin, Nicolas P. D. Sawaya,
+    Kanav Setia, Sukin Sim, Damian S. Steiger, Mark Steudtner, Qiming Sun,
+    Wei Sun, Daochen Wang, Fang Zhang and Ryan Babbush.
     *OpenFermion: The Electronic Structure Package for Quantum Computers*.
     `arXiv:1710.07629 <https://arxiv.org/abs/1710.07629>`__. 2017.
 


### PR DESCRIPTION
Do not merge yet. We should really change the way we list authors on OpenFermion-Cirq. Should we list authors the same way we list authors for OpenFermion (everybody who has contributed to any of the plugins?). Or should we just list the OpenFermion-Cirq authors? Because currently, we only list some subset of the OpenFermion-Cirq authors, and that's no good.